### PR TITLE
Fix typo in the LICENSE.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-T License
+MIT License
 
 Copyright (c) [year] [fullname]
 


### PR DESCRIPTION
As I assume it was by mistake; functionally it wasn't a MIT license :)