### PR TITLE
Mark Answer, Completion, and Search APIs as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ as well as an example project using the client.
 - [Completions](https://beta.openai.com/docs/api-reference/completions)
 - [Edits](https://beta.openai.com/docs/api-reference/edits)
 - [Embeddings](https://beta.openai.com/docs/api-reference/embeddings)
-- [Searches](https://beta.openai.com/docs/api-reference/searches)
-- [Classifications](https://beta.openai.com/docs/api-reference/classifications)
-- [Answers](https://beta.openai.com/docs/api-reference/answers)
 - [Files](https://beta.openai.com/docs/api-reference/files)
 - [Fine-tunes](https://beta.openai.com/docs/api-reference/fine-tunes)
 - [Moderations](https://beta.openai.com/docs/api-reference/moderations)
+
+#### Deprecated by OpenAI but still working as of 8/19/22
+- [Searches](https://beta.openai.com/docs/api-reference/searches)
+- [Classifications](https://beta.openai.com/docs/api-reference/classifications)
+- [Answers](https://beta.openai.com/docs/api-reference/answers)
 
 ## Usage
 

--- a/api/src/main/java/com/theokanning/openai/answer/AnswerRequest.java
+++ b/api/src/main/java/com/theokanning/openai/answer/AnswerRequest.java
@@ -13,6 +13,7 @@ import java.util.Map;
  * Documentation taken from
  * https://beta.openai.com/docs/api-reference/answers/create
  */
+@Deprecated
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/api/src/main/java/com/theokanning/openai/answer/AnswerResult.java
+++ b/api/src/main/java/com/theokanning/openai/answer/AnswerResult.java
@@ -9,6 +9,7 @@ import java.util.List;
  *
  * https://beta.openai.com/docs/api-reference/answers/create
  */
+@Deprecated
 @Data
 public class AnswerResult {
     /**

--- a/api/src/main/java/com/theokanning/openai/answer/Document.java
+++ b/api/src/main/java/com/theokanning/openai/answer/Document.java
@@ -7,6 +7,7 @@ import lombok.Data;
  *
  * https://beta.openai.com/docs/api-reference/classifications/create
  */
+@Deprecated
 @Data
 public class Document {
     /**

--- a/api/src/main/java/com/theokanning/openai/classification/ClassificationRequest.java
+++ b/api/src/main/java/com/theokanning/openai/classification/ClassificationRequest.java
@@ -12,6 +12,7 @@ import java.util.Map;
  * Documentation taken from
  * https://beta.openai.com/docs/api-reference/classifications/create
  */
+@Deprecated
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/api/src/main/java/com/theokanning/openai/classification/ClassificationResult.java
+++ b/api/src/main/java/com/theokanning/openai/classification/ClassificationResult.java
@@ -9,6 +9,7 @@ import java.util.List;
  * <
  * https://beta.openai.com/docs/api-reference/classifications/create
  */
+@Deprecated
 @Data
 public class ClassificationResult {
 

--- a/api/src/main/java/com/theokanning/openai/classification/Example.java
+++ b/api/src/main/java/com/theokanning/openai/classification/Example.java
@@ -7,6 +7,7 @@ import lombok.Data;
  *
  * https://beta.openai.com/docs/api-reference/classifications/create
  */
+@Deprecated
 @Data
 public class Example {
     /**

--- a/api/src/main/java/com/theokanning/openai/search/SearchRequest.java
+++ b/api/src/main/java/com/theokanning/openai/search/SearchRequest.java
@@ -14,6 +14,7 @@ import java.util.List;
  *
  * https://beta.openai.com/docs/api-reference/searches
  */
+@Deprecated
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/api/src/main/java/com/theokanning/openai/search/SearchResult.java
+++ b/api/src/main/java/com/theokanning/openai/search/SearchResult.java
@@ -7,6 +7,7 @@ import lombok.Data;
  *
  * https://beta.openai.com/docs/api-reference/searches
  */
+@Deprecated
 @Data
 public class SearchResult {
     /**

--- a/client/src/main/java/com/theokanning/openai/OpenAiApi.java
+++ b/client/src/main/java/com/theokanning/openai/OpenAiApi.java
@@ -41,15 +41,6 @@ public interface OpenAiApi {
     @POST("/v1/engines/{engine_id}/embeddings")
     Single<EmbeddingResult> createEmbeddings(@Path("engine_id") String engineId, @Body EmbeddingRequest request);
 
-    @POST("/v1/engines/{engine_id}/search")
-    Single<OpenAiResponse<SearchResult>> search(@Path("engine_id") String engineId, @Body SearchRequest request);
-
-    @POST("v1/classifications")
-    Single<ClassificationResult> createClassification(@Body ClassificationRequest request);
-
-    @POST("v1/answers")
-    Single<AnswerResult> createAnswer(@Body AnswerRequest request);
-
     @GET("/v1/files")
     Single<OpenAiResponse<File>> listFiles();
 
@@ -86,4 +77,16 @@ public interface OpenAiApi {
 
     @POST("/v1/moderations")
     Single<ModerationResult> createModeration(@Body ModerationRequest request);
+
+    @Deprecated
+    @POST("v1/answers")
+    Single<AnswerResult> createAnswer(@Body AnswerRequest request);
+
+    @Deprecated
+    @POST("v1/classifications")
+    Single<ClassificationResult> createClassification(@Body ClassificationRequest request);
+
+    @Deprecated
+    @POST("/v1/engines/{engine_id}/search")
+    Single<OpenAiResponse<SearchResult>> search(@Path("engine_id") String engineId, @Body SearchRequest request);
 }

--- a/client/src/main/java/com/theokanning/openai/OpenAiService.java
+++ b/client/src/main/java/com/theokanning/openai/OpenAiService.java
@@ -98,18 +98,6 @@ public class OpenAiService {
         return api.createEmbeddings(engineId, request).blockingGet();
     }
 
-    public List<SearchResult> search(String engineId, SearchRequest request) {
-        return api.search(engineId, request).blockingGet().data;
-    }
-
-    public ClassificationResult createClassification(ClassificationRequest request) {
-        return api.createClassification(request).blockingGet();
-    }
-
-    public AnswerResult createAnswer(AnswerRequest request) {
-        return api.createAnswer(request).blockingGet();
-    }
-
     public List<File> listFiles() {
         return api.listFiles().blockingGet().data;
     }
@@ -161,5 +149,20 @@ public class OpenAiService {
 
     public ModerationResult createModeration(ModerationRequest request) {
         return api.createModeration(request).blockingGet();
+    }
+
+    @Deprecated
+    public AnswerResult createAnswer(AnswerRequest request) {
+        return api.createAnswer(request).blockingGet();
+    }
+
+    @Deprecated
+    public ClassificationResult createClassification(ClassificationRequest request) {
+        return api.createClassification(request).blockingGet();
+    }
+
+    @Deprecated
+    public List<SearchResult> search(String engineId, SearchRequest request) {
+        return api.search(engineId, request).blockingGet().data;
     }
 }

--- a/example/src/main/java/example/OpenAiApiExample.java
+++ b/example/src/main/java/example/OpenAiApiExample.java
@@ -3,9 +3,6 @@ package example;
 import com.theokanning.openai.OpenAiService;
 import com.theokanning.openai.completion.CompletionRequest;
 import com.theokanning.openai.engine.Engine;
-import com.theokanning.openai.search.SearchRequest;
-
-import java.util.Arrays;
 
 class OpenAiApiExample {
     public static void main(String... args) {
@@ -26,12 +23,5 @@ class OpenAiApiExample {
                 .user("testing")
                 .build();
         service.createCompletion("ada", completionRequest).getChoices().forEach(System.out::println);
-
-        System.out.println("\nSearching documents...");
-        SearchRequest searchRequest = SearchRequest.builder()
-                .documents(Arrays.asList("Water", "Earth", "Electricity", "Fire"))
-                .query("Pikachu")
-                .build();
-        service.search("ada", searchRequest).forEach(System.out::println);
     }
 }


### PR DESCRIPTION
OpenAI has officially deprecated these APIs, but I'll leave them in as long as the endpoints still work
The engines api is also deprecated, but I'll get to that when I add model support.