### PR TITLE
Add deprecation info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 ![Maven Central](https://img.shields.io/maven-central/v/com.theokanning.openai-gpt3-java/client?color=blue)
+
+> ⚠️The [Answers](https://help.openai.com/en/articles/6233728-answers-transition-guide), 
+>[Classifications](https://help.openai.com/en/articles/6272941-classifications-transition-guide), 
+>and [Searches](https://help.openai.com/en/articles/6272952-search-transition-guide) APIs are deprecated, 
+>and will stop working on December 3rd, 2022.
+
+> ⚠️OpenAI has deprecated all Engine-based APIs. See [Deprecated Endpoints](https://github.com/TheoKanning/openai-java#deprecated-endpoints) below for more info.
+
 # OpenAI-Java
 Java libraries for using OpenAI's GPT-3 api.
 
@@ -9,7 +17,7 @@ Includes the following artifacts:
 as well as an example project using the client.
 
 ## Supported APIs
-- [Engines](https://beta.openai.com/docs/api-reference/engines)
+- [Models](https://beta.openai.com/docs/api-reference/models)
 - [Completions](https://beta.openai.com/docs/api-reference/completions)
 - [Edits](https://beta.openai.com/docs/api-reference/edits)
 - [Embeddings](https://beta.openai.com/docs/api-reference/embeddings)
@@ -17,10 +25,11 @@ as well as an example project using the client.
 - [Fine-tunes](https://beta.openai.com/docs/api-reference/fine-tunes)
 - [Moderations](https://beta.openai.com/docs/api-reference/moderations)
 
-#### Deprecated by OpenAI but still working as of 8/19/22
+#### Deprecated by OpenAI
 - [Searches](https://beta.openai.com/docs/api-reference/searches)
 - [Classifications](https://beta.openai.com/docs/api-reference/classifications)
 - [Answers](https://beta.openai.com/docs/api-reference/answers)
+- [Engines](https://beta.openai.com/docs/api-reference/engines)
 
 ## Usage
 
@@ -55,6 +64,13 @@ All the [example](example/src/main/java/example/OpenAiApiExample.java) project r
 export OPENAI_TOKEN="sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 ./gradlew example:run
 ```
+
+## Deprecated Endpoints
+OpenAI has deprecated engine-based endpoints in favor of model-based endpoints. 
+For example, instead of using `v1/engines/{engine_id}/completions`, switch to `v1/completions` and specify the model in the `CompletionRequest`.
+The code includes upgrade instructions for all deprecated endpoints.
+
+I won't remove the old endpoints from this library until OpenAI shuts them down.
 
 ## License
 Published under the MIT License


### PR DESCRIPTION
Answers, Classifications, Searchs, and old v1/engine endpoints are all deprecated.