### PR TITLE
Updating example to not use new api

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ or
 ### Using OpenAiService
 If you're looking for the fastest solution, import the `client` and use [OpenAiService](client/src/main/java/com/theokanning/openai/OpenAiService.java).
 ```
-OpenAiService service = new OpenAiService(your_token)
+OpenAiService service = new OpenAiService("your_token");
 CompletionRequest completionRequest = CompletionRequest.builder()
         .prompt("Somebody once told me the world is gonna roll me")
+        .model("ada")
         .echo(true)
         .build();
-service.createCompletion("ada", completionRequest).getChoices().forEach(System.out::println);
+service.createCompletion( completionRequest).getChoices().forEach(System.out::println);
 ```
 
 ### Using OpenAiApi Retrofit client


### PR DESCRIPTION
```java
/** Use {@link OpenAiService#createCompletion(CompletionRequest)} and {@link CompletionRequest#model}instead */
@Deprecated
public CompletionResult createCompletion(String engineId, CompletionRequest request)
```

The example in the readme uses the old completion, which should be updated as it is the one people probably use at first. 
I've also formatted it so after pasting it into an editor you won't get syntax errors. (Added semicolon and made API key a string)