### PR TITLE
Exposed initialization state for service (for scenario testing).

### DIFF
--- a/client/src/main/java/com/theokanning/openai/OpenAiService.java
+++ b/client/src/main/java/com/theokanning/openai/OpenAiService.java
@@ -29,27 +29,56 @@ import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static java.time.Duration.ofSeconds;
+
 public class OpenAiService {
 
-    OpenAiApi api;
+    private static final String BASE_URL = "https://api.openai.com/";
+
+    final OpenAiApi api;
 
     /**
      * Creates a new OpenAiService that wraps OpenAiApi
+     *
      * @param token OpenAi token string "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
      */
-    public OpenAiService(String token) {
-        this(token, 10);
+    public OpenAiService(final String token) {
+        this(token, BASE_URL, ofSeconds(10));
     }
 
     /**
      * Creates a new OpenAiService that wraps OpenAiApi
-     * @param token OpenAi token string "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+     *
+     * @param token   OpenAi token string "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
      * @param timeout http read timeout in seconds, 0 means no timeout
+     * @deprecated use {@link OpenAiService(String, Duration)}
      */
-    public OpenAiService(String token, int timeout) {
+    @Deprecated
+    public OpenAiService(final String token, final int timeout) {
+        this(token, BASE_URL, ofSeconds(timeout));
+    }
+
+    /**
+     * Creates a new OpenAiService that wraps OpenAiApi
+     *
+     * @param token   OpenAi token string "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+     * @param timeout http read timeout, Duration.ZERO means no timeout
+     */
+    public OpenAiService(final String token, final Duration timeout) {
+        this(token, BASE_URL, timeout);
+    }
+
+    /**
+     * Creates a new OpenAiService that wraps OpenAiApi
+     *
+     * @param token   OpenAi token string "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+     * @param timeout http read timeout, Duration.ZERO means no timeout
+     */
+    public OpenAiService(final String token, final String baseUrl, final Duration timeout) {
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
@@ -58,11 +87,11 @@ public class OpenAiService {
         OkHttpClient client = new OkHttpClient.Builder()
                 .addInterceptor(new AuthenticationInterceptor(token))
                 .connectionPool(new ConnectionPool(5, 1, TimeUnit.SECONDS))
-                .readTimeout(timeout, TimeUnit.SECONDS)
+                .readTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS)
                 .build();
 
         Retrofit retrofit = new Retrofit.Builder()
-                .baseUrl("https://api.openai.com/")
+                .baseUrl(baseUrl)
                 .client(client)
                 .addConverterFactory(JacksonConverterFactory.create(mapper))
                 .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
@@ -73,9 +102,10 @@ public class OpenAiService {
 
     /**
      * Creates a new OpenAiService that wraps OpenAiApi
+     *
      * @param api OpenAiApi instance to use for all methods
      */
-    public OpenAiService(OpenAiApi api) {
+    public OpenAiService(final OpenAiApi api) {
         this.api = api;
     }
 
@@ -91,7 +121,9 @@ public class OpenAiService {
         return api.createCompletion(request).blockingGet();
     }
 
-    /** Use {@link OpenAiService#createCompletion(CompletionRequest)} and {@link CompletionRequest#model}instead */
+    /**
+     * Use {@link OpenAiService#createCompletion(CompletionRequest)} and {@link CompletionRequest#model}instead
+     */
     @Deprecated
     public CompletionResult createCompletion(String engineId, CompletionRequest request) {
         return api.createCompletion(engineId, request).blockingGet();
@@ -101,7 +133,9 @@ public class OpenAiService {
         return api.createEdit(request).blockingGet();
     }
 
-    /** Use {@link OpenAiService#createEdit(EditRequest)} and {@link EditRequest#model}instead */
+    /**
+     * Use {@link OpenAiService#createEdit(EditRequest)} and {@link EditRequest#model}instead
+     */
     @Deprecated
     public EditResult createEdit(String engineId, EditRequest request) {
         return api.createEdit(engineId, request).blockingGet();
@@ -111,7 +145,9 @@ public class OpenAiService {
         return api.createEmbeddings(request).blockingGet();
     }
 
-    /** Use {@link OpenAiService#createEmbeddings(EmbeddingRequest)} and {@link EmbeddingRequest#model}instead */
+    /**
+     * Use {@link OpenAiService#createEmbeddings(EmbeddingRequest)} and {@link EmbeddingRequest#model}instead
+     */
     @Deprecated
     public EmbeddingResult createEmbeddings(String engineId, EmbeddingRequest request) {
         return api.createEmbeddings(engineId, request).blockingGet();


### PR DESCRIPTION
I would like to propose a change to expose the base-url as an (optional) parameter in the constructor; will ease implementation of scenario-style testing with proper mocked OpenAI payloads.

Also, finalisation of internal state and usage of java.time.Duration instead of primitive.
