### PR TITLE
Added support for 'OpenAI-Organization' header

### DIFF
--- a/client/src/main/java/com/theokanning/openai/OrganizationInterceptor.java
+++ b/client/src/main/java/com/theokanning/openai/OrganizationInterceptor.java
@@ -1,0 +1,30 @@
+package com.theokanning.openai;
+
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * OkHttp Interceptor that adds an authorization organizationId header
+ */
+public class OrganizationInterceptor implements Interceptor {
+
+    private final String organizationId;
+
+    OrganizationInterceptor(String organizationId) {
+        this.organizationId = organizationId;
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+      if (organizationId ==  null) {
+        return chain.proceed(chain.request());
+      }
+        Request request = chain.request()
+            .newBuilder()
+            .header("OpenAI-Organization", organizationId)
+            .build();
+        return chain.proceed(request);
+    }
+}


### PR DESCRIPTION
According to the [OpenAI docs](https://beta.openai.com/docs/api-reference/requesting-organization), when a user belongs to multiple organizations you can provide the `organizationId` as an `HttpHeader` for billing/usage purposes.

It is also listed as a [best practice](https://beta.openai.com/docs/guides/production-best-practices/setting-up-your-organization) on their docs.

This PR aims at introducing the possibility to provide an `organizationId` when creating the `OpenAiService`. Bear in mind this attribute is optional making this change backwards compatible.
