### PR TITLE
fix(client): add additional checks for the timeout

### DIFF
--- a/client/src/main/java/com/theokanning/openai/OpenAiService.java
+++ b/client/src/main/java/com/theokanning/openai/OpenAiService.java
@@ -71,9 +71,11 @@ public class OpenAiService {
      * Creates a new OpenAiService that wraps OpenAiApi
      *
      * @param token   OpenAi token string "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-     * @param timeout http read timeout, Duration.ZERO means no timeout
+     * @param timeout http read timeout, Duration.ZERO means no timeout, Duration cannot be negative
      */
     public OpenAiService(final String token, final String baseUrl, final Duration timeout) {
+        if(token == null || baseUrl == null || timeout == null) return;
+        if(timeout.isNegative()) return;
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/example/src/main/java/example/OpenAiApiExample.java
+++ b/example/src/main/java/example/OpenAiApiExample.java
@@ -5,9 +5,14 @@ import com.theokanning.openai.completion.CompletionRequest;
 
 class OpenAiApiExample {
     public static void main(String... args) {
+        OpenAiApiExample openAiApiExample = new OpenAiApiExample();
+        openAiApiExample.OpenAiServiceWithOnlyToken();
+        openAiApiExample.OpenAiServiceWithTokenAndUrlAndTimeOut();
+    }
+
+    public void OpenAiServiceWithOnlyToken(){
         String token = System.getenv("OPENAI_TOKEN");
         OpenAiService service = new OpenAiService(token);
-
         System.out.println("\nCreating completion...");
         CompletionRequest completionRequest = CompletionRequest.builder()
                 .model("ada")
@@ -17,4 +22,19 @@ class OpenAiApiExample {
                 .build();
         service.createCompletion(completionRequest).getChoices().forEach(System.out::println);
     }
+
+    public void OpenAiServiceWithTokenAndUrlAndTimeOut(){
+        String token = System.getenv("OPENAI_TOKEN");
+        final String BASE_URL = "https://api.openai.com/";
+        OpenAiService service = new OpenAiService(token, BASE_URL,  Duration.ofSeconds(10));
+        System.out.println("\nCreating completion...");
+        CompletionRequest completionRequest = CompletionRequest.builder()
+                .model("ada")
+                .prompt("Somebody once told me the world is gonna roll me")
+                .echo(true)
+                .user("testing")
+                .build();
+        service.createCompletion(completionRequest).getChoices().forEach(System.out::println);
+    }
+
 }


### PR DESCRIPTION
- Check if the value of token, url and timeout is null and return if they are null
- Check if the value of timeout is negative, if it's negative return.
- If this checks are not needed and only OpenAiService(final String token) is exposed, we should make OpenAiService(final String token, final String baseUrl, final Duration timeout) as private.