### PR TITLE
JsonProperties avoiding 'Unrecognized request argument supplied' erro…

### DIFF
--- a/api/src/main/java/com/theokanning/openai/completion/CompletionRequest.java
+++ b/api/src/main/java/com/theokanning/openai/completion/CompletionRequest.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * A request for OpenAi to generate a predicted completion for a prompt.
  * All fields are nullable.
@@ -36,6 +38,7 @@ public class CompletionRequest {
      * Requests can use up to 2048 tokens shared between prompt and completion.
      * (One token is roughly 4 characters for normal English text)
      */
+    @JsonProperty("max_tokens")
     Integer maxTokens;
 
     /**
@@ -53,6 +56,7 @@ public class CompletionRequest {
      *
      * We generally recommend using this or {@link CompletionRequest#temperature} but not both.
      */
+    @JsonProperty("top_p")
     Double topP;
 
     /**
@@ -93,12 +97,14 @@ public class CompletionRequest {
      * Number between 0 and 1 (default 0) that penalizes new tokens based on whether they appear in the text so far.
      * Increases the model's likelihood to talk about new topics.
      */
+    @JsonProperty("presence_penalty")
     Double presencePenalty;
 
     /**
      * Number between 0 and 1 (default 0) that penalizes new tokens based on their existing frequency in the text so far.
      * Decreases the model's likelihood to repeat the same line verbatim.
      */
+    @JsonProperty("frequency_penalty")
     Double frequencyPenalty;
 
     /**
@@ -109,6 +115,7 @@ public class CompletionRequest {
      * When used with {@link CompletionRequest#n}, best_of controls the number of candidate completions and n specifies how many to return,
      * best_of must be greater than n.
      */
+    @JsonProperty("best_of")
     Integer bestOf;
 
     /**
@@ -118,6 +125,7 @@ public class CompletionRequest {
      *
      * https://beta.openai.com/docs/api-reference/completions/create#completions/create-logit_bias
      */
+    @JsonProperty("logit_bias")
     Map<String, Integer> logitBias;
 
     /**

--- a/api/src/main/java/com/theokanning/openai/image/CreateImageRequest.java
+++ b/api/src/main/java/com/theokanning/openai/image/CreateImageRequest.java
@@ -1,5 +1,7 @@
 package com.theokanning.openai.image;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.*;
 
 /**
@@ -33,6 +35,7 @@ public class CreateImageRequest {
     /**
      * The format in which the generated images are returned. Must be one of url or b64_json. Defaults to url.
      */
+    @JsonProperty("response_format")
     String responseFormat;
 
     /**


### PR DESCRIPTION
…r in Image and Completion Requests

For developers that don't use the client library.

Example was made with RestTemplate.

EX. ERROR:
org.springframework.web.client.HttpClientErrorException$BadRequest: 400 Bad Request: "{<EOL>  "error": {<EOL>    "message": "Unrecognized request argument supplied: logitBias",<EOL>    "type": "invalid_request_error",<EOL>    "param": null,<EOL>    "code": null<EOL>  }<EOL>}<EOL>"