### PR TITLE
Add no arg constructor to ChatCompletionRequest

### DIFF
--- a/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionRequest.java
+++ b/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionRequest.java
@@ -1,13 +1,17 @@
 package com.theokanning.openai.completion.chat;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.Map;
 
 @Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class ChatCompletionRequest {
 
     /**


### PR DESCRIPTION
This change resolves issue https://github.com/TheoKanning/openai-java/issues/146 by add noArgConstructor annotation to ChatCompletionRequest