### PR TITLE
Add proxy instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ OpenAiApi api = retrofit.create(OpenAiApi.class);
 OpenAiService service = new OpenAiService(api);
 ```
 
+### Adding a Proxy
+To use a proxy, modify the OkHttp client as shown below:
+```java
+ObjectMapper mapper = defaultObjectMapper();
+Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host, port));
+OkHttpClient client = defaultClient(token, timeout)
+        .newBuilder()
+        .proxy(proxy)
+        .build();
+Retrofit retrofit = defaultRetrofit(client, mapper);
+OpenAiApi api = retrofit.create(OpenAiApi.class);
+OpenAiService service = new OpenAiService(api);
+```
 
 
 


### PR DESCRIPTION
There are many ways to set a proxy, but this is the simplest I've seen.