### PR TITLE
Upgrade jackson annotations

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-library'
 apply plugin: "com.vanniktech.maven.publish"
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.9.0'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.2'
     compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'java-library'
 apply plugin: "com.vanniktech.maven.publish"
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.2'
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
+    implementation libs.jacksoAnnotations
+    compileOnly libs.lombok
+    annotationProcessor libs.lombok
 
-    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
-    testImplementation(platform('org.junit:junit-bom:5.8.2'))
+    testImplementation libs.jacksonDatabind
+    testImplementation(platform(libs.junitBom))
     testImplementation('org.junit.jupiter:junit-jupiter')
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -3,11 +3,11 @@ apply plugin: "com.vanniktech.maven.publish"
 
 dependencies {
     api project(":api")
-    api 'com.squareup.retrofit2:retrofit:2.9.0'
-    api 'com.squareup.retrofit2:adapter-rxjava2:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-jackson:2.9.0'
+    api libs.retrofit
+    api libs.retrofitRxJava2
+    implementation libs.retrofitJackson
 
-    testImplementation(platform('org.junit:junit-bom:5.8.2'))
+    testImplementation(platform(libs.junitBom))
     testImplementation('org.junit.jupiter:junit-jupiter')
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[libraries]
+jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version = "2.14.2" }
+jacksoAnnotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version = "2.14.2" }
+lombok = { module = "org.projectlombok:lombok", version = "1.18.24" }
+junitBom = { module = "org.junit:junit-bom", version = "5.8.2" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version = "2.9.0" }
+retrofitJackson = { module = "com.squareup.retrofit2:converter-jackson", version = "2.9.0" }
+retrofitRxJava2 = { module = "com.squareup.retrofit2:adapter-rxjava2", version = "2.9.0" }
+retrofitMock = { module = "com.squareup.retrofit2:retrofit-mock", version = "2.9.0" }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -3,13 +3,13 @@ apply plugin: "com.vanniktech.maven.publish"
 
 dependencies {
     api project(":client")
-    api 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-jackson:2.9.0'
+    api libs.retrofit
+    implementation libs.retrofitRxJava2
+    implementation libs.retrofitJackson
 
-    testImplementation(platform('org.junit:junit-bom:5.8.2'))
+    testImplementation(platform(libs.junitBom))
     testImplementation 'org.junit.jupiter:junit-jupiter'
-    testImplementation 'com.squareup.retrofit2:retrofit-mock:2.9.0'
+    testImplementation libs.retrofitMock
 }
 
 compileJava {


### PR DESCRIPTION
Closes #231

This PR consists of two commits:

* The first upgrades jackson-annotations to 2.14.2
* The second moves the dependency version declarations into a shared version catalog. This is not strictly necessary to address my raised issue, but as both client and service use retrofit, this change future-proofs the dependency management, so that all subprojects are guaranteed to use the same dependency versions.