### PR TITLE
Exit SSE readLine loop immediately if Flowable is disposed

### DIFF
--- a/service/src/main/java/com/theokanning/openai/service/ResponseBodyCallback.java
+++ b/service/src/main/java/com/theokanning/openai/service/ResponseBodyCallback.java
@@ -58,7 +58,7 @@ public class ResponseBodyCallback implements Callback<ResponseBody> {
             String line;
             SSE sse = null;
 
-            while ((line = reader.readLine()) != null) {
+            while (!emitter.isCancelled() && (line = reader.readLine()) != null) {
                 if (line.startsWith("data:")) {
                     String data = line.substring(5).trim();
                     sse = new SSE(data);
@@ -86,7 +86,7 @@ public class ResponseBodyCallback implements Callback<ResponseBody> {
                 try {
                     reader.close();
                 } catch (IOException e) {
-					// do nothing
+					          // do nothing
                 }
             }
         }


### PR DESCRIPTION
If Flowable is disposed or cancelled, the SSE readLine loop should be exited immediately.

```diff
- while ((line = reader.readLine()) != null) {
+ while (!emitter.isCancelled() && (line = reader.readLine()) != null)
```

BTW, fixed a code format nit:
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/5214214/232289987-d26d691b-0fb2-497a-8250-8679d4abca3f.png) | ![image](https://user-images.githubusercontent.com/5214214/232289838-833a6cad-c764-4d28-8cae-d67dcb5d27b5.png) |
