### PR TITLE
:bug: missing name field

### DIFF
--- a/api/src/main/java/com/theokanning/openai/completion/chat/ChatMessage.java
+++ b/api/src/main/java/com/theokanning/openai/completion/chat/ChatMessage.java
@@ -1,8 +1,6 @@
 package com.theokanning.openai.completion.chat;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * <p>Each object has a role (either "system", "user", or "assistant") and content (the content of the message). Conversations can be as short as 1 message or fill many pages.</p>
@@ -15,7 +13,8 @@ import lombok.NoArgsConstructor;
  * see <a href="https://platform.openai.com/docs/guides/chat/introduction">OpenAi documentation</a>
  */
 @Data
-@NoArgsConstructor
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
 @AllArgsConstructor
 public class ChatMessage {
 
@@ -23,6 +22,10 @@ public class ChatMessage {
 	 * Must be either 'system', 'user', or 'assistant'.<br>
 	 * You may use {@link ChatMessageRole} enum.
 	 */
+	@NonNull
 	String role;
+	@NonNull
 	String content;
+	//name is optional, The name of the author of this message. May contain a-z, A-Z, 0-9, and underscores, with a maximum length of 64 characters.
+	String name;
 }


### PR DESCRIPTION
Super easy fix. Missing a field in ChatMessage. This field is used sometimes to startup the assistant.