### PR TITLE
add-ability-to-configure-base-url

### DIFF
--- a/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
+++ b/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
@@ -409,6 +409,15 @@ public class OpenAiService {
                 .build();
     }
 
+    public static Retrofit customRetrofit(String baseUrl, OkHttpClient client, ObjectMapper mapper) {
+        return new Retrofit.Builder()
+                .baseUrl(baseUrl)
+                .client(client)
+                .addConverterFactory(JacksonConverterFactory.create(mapper))
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+                .build();
+    }
+
     public Flowable<ChatMessageAccumulator> mapStreamToAccumulator(Flowable<ChatCompletionChunk> flowable) {
         ChatFunctionCall functionCall = new ChatFunctionCall(null, null);
         ChatMessage accumulatedMessage = new ChatMessage(ChatMessageRole.ASSISTANT.value(), null);


### PR DESCRIPTION
useful to specify custom base URL for testing purposes with mock server in integration tests