### PR TITLE
Support all audio response formats

### DIFF
--- a/client/src/main/java/com/theokanning/openai/client/OpenAiApi.java
+++ b/client/src/main/java/com/theokanning/openai/client/OpenAiApi.java
@@ -120,7 +120,7 @@ public interface OpenAiApi {
     Single<ResponseBody> createTranscription(@Body RequestBody requestBody);
 
     @POST("/v1/audio/translations")
-    Single<TranslationResult> createTranslation(@Body RequestBody requestBody);
+    Single<ResponseBody> createTranslation(@Body RequestBody requestBody);
 
     @POST("/v1/moderations")
     Single<ModerationResult> createModeration(@Body ModerationRequest request);

--- a/client/src/main/java/com/theokanning/openai/client/OpenAiApi.java
+++ b/client/src/main/java/com/theokanning/openai/client/OpenAiApi.java
@@ -117,7 +117,7 @@ public interface OpenAiApi {
     Single<ImageResult> createImageVariation(@Body RequestBody requestBody);
 
     @POST("/v1/audio/transcriptions")
-    Single<TranscriptionResult> createTranscription(@Body RequestBody requestBody);
+    Single<ResponseBody> createTranscription(@Body RequestBody requestBody);
 
     @POST("/v1/audio/translations")
     Single<TranslationResult> createTranslation(@Body RequestBody requestBody);

--- a/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
+++ b/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
@@ -280,7 +280,25 @@ public class OpenAiService {
             builder.addFormDataPart("language", request.getLanguage());
         }
 
-        return execute(api.createTranscription(builder.build()));
+        try (ResponseBody responseBody = execute(api.createTranscription(builder.build()))) {
+            final String responseFormat = request.getResponseFormat() == null ? "json" : request.getResponseFormat();
+            switch (responseFormat) {
+                case "json":
+                case "verbose_json":
+                    final ObjectMapper objectMapper = defaultObjectMapper();
+                    return objectMapper.readValue(responseBody.string(), TranscriptionResult.class);
+                case "text":
+                case "vtt":
+                case "srt":
+                    final TranscriptionResult result = new TranscriptionResult();
+                    result.setText(responseBody.string());
+                    return result;
+                default:
+                    throw new IllegalArgumentException("Unknown response format: " + responseFormat);
+            }
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     public TranslationResult createTranslation(CreateTranslationRequest request, String audioPath) {


### PR DESCRIPTION
The current API should support all audio response formats currently offered by OpenAI Audio endpoint:

* The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.
* The format of the translation output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.