### PR TITLE
Add workflow to make sure code compiles on pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,11 +1,11 @@
-name: Test
+name: Compile
 
 on:
-  push:
+  pull_request:
     branches: [ main ]
 
 jobs:
-  test:
+  compile:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,7 +17,5 @@ jobs:
         distribution: temurin
         java-version: 8
 
-    - name: Test
-      run: ./gradlew test --stacktrace
-      env:
-        OPENAI_TOKEN: ${{ secrets.OPENAI_TOKEN }}
+    - name: Compile
+      run: ./gradlew compileJava compileTestJava


### PR DESCRIPTION
Pull requests can't run most tests because they require an OpenAI token secret, but they should at least compile.