### PR TITLE
Unwrap SocketTimeoutException and update tests accordingly

### DIFF
--- a/example/src/main/java/example/OpenAiApiFunctionsExample.java
+++ b/example/src/main/java/example/OpenAiApiFunctionsExample.java
@@ -7,6 +7,7 @@ import com.theokanning.openai.completion.chat.ChatCompletionRequest.ChatCompleti
 import com.theokanning.openai.service.FunctionExecutor;
 import com.theokanning.openai.service.OpenAiService;
 
+import java.net.SocketTimeoutException;
 import java.util.*;
 
 class OpenAiApiFunctionsExample {
@@ -38,7 +39,7 @@ class OpenAiApiFunctionsExample {
         }
     }
 
-    public static void main(String... args) {
+    public static void main(String... args) throws SocketTimeoutException {
         String token = System.getenv("OPENAI_TOKEN");
         OpenAiService service = new OpenAiService(token);
 

--- a/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
+++ b/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
@@ -139,7 +139,7 @@ public class OpenAiService {
         try {
             return execute(api.createChatCompletion(request));
         } catch (RuntimeException e) {
-            if (e.getCause() != null && e.getCause() instanceof SocketTimeoutException && e.getCause().getMessage() == "hello world")
+            if (e.getCause() != null && e.getCause() instanceof SocketTimeoutException)
                 throw new SocketTimeoutException(e.getCause().getMessage());
             else
                 throw e;

--- a/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
+++ b/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
@@ -49,6 +49,7 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
@@ -134,8 +135,15 @@ public class OpenAiService {
         return stream(api.createCompletionStream(request), CompletionChunk.class);
     }
 
-    public ChatCompletionResult createChatCompletion(ChatCompletionRequest request) {
-        return execute(api.createChatCompletion(request));
+    public ChatCompletionResult createChatCompletion(ChatCompletionRequest request) throws SocketTimeoutException{
+        try {
+            return execute(api.createChatCompletion(request));
+        } catch (RuntimeException e) {
+            if (e.getCause() != null && e.getCause() instanceof SocketTimeoutException && e.getCause().getMessage() == "hello world")
+                throw new SocketTimeoutException(e.getCause().getMessage());
+            else
+                throw e;
+        }
     }
 
     public Flowable<ChatCompletionChunk> streamChatCompletion(ChatCompletionRequest request) {

--- a/service/src/test/java/com/theokanning/openai/service/ChatCompletionTest.java
+++ b/service/src/test/java/com/theokanning/openai/service/ChatCompletionTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.theokanning.openai.completion.chat.*;
 import org.junit.jupiter.api.Test;
 
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -47,7 +48,7 @@ class ChatCompletionTest {
     OpenAiService service = new OpenAiService(token);
 
     @Test
-    void createChatCompletion() {
+    void createChatCompletion() throws SocketTimeoutException {
         final List<ChatMessage> messages = new ArrayList<>();
         final ChatMessage systemMessage = new ChatMessage(ChatMessageRole.SYSTEM.value(), "You are a dog and will speak as such.");
         messages.add(systemMessage);
@@ -88,7 +89,7 @@ class ChatCompletionTest {
     }
 
     @Test
-    void createChatCompletionWithFunctions() {
+    void createChatCompletionWithFunctions() throws SocketTimeoutException {
         final List<ChatFunction> functions = Collections.singletonList(ChatFunction.builder()
                 .name("get_weather")
                 .description("Get the current weather in a given location")


### PR DESCRIPTION
Hi, thanks for the great work, it's very simple and easy to use.

When working with the library I found it a bit strange that currently the API returns an OpenAiHttpException when the token-per-minute wall is met but only a generic RuntimeException when a timeout on the OpenAI APIs is reached. This is a bit counterintuitive to me because, in order to catch it, I have to get the parent exception via the `getCause()` method and check if this was rather of type `SocketTimeoutException`.

This PR raises the level of the exception to the more specific `SocketTimeoutException`, so that it's easier on the client-side to handle these cases. Tests are updated accordingly so to pass successfully.

Note that this exception could easily be integrated into an `OpenAiHttpException` as I believe mean similar concepts. Still, I didn't make the effort to do it but could be easily integrated to this PR.

@TheoKanning @aaronuu @Grogdunn 