### PR TITLE
Fix fine-tuning test email notifications

### DIFF
--- a/service/src/test/java/com/theokanning/openai/service/FineTuningTest.java
+++ b/service/src/test/java/com/theokanning/openai/service/FineTuningTest.java
@@ -80,10 +80,13 @@ public class FineTuningTest {
     }
 
     @Test
-    @Order(2)
-    void cancelFineTuningJob() {
+    @Order(3)
+    void cancelFineTuningJob() throws Exception {
         FineTuningJob fineTuningJob = service.cancelFineTuningJob(fineTuningJobId);
 
         assertEquals("cancelled", fineTuningJob.getStatus());
+
+        // wait before cleaning up to prevent job failure emails
+        TimeUnit.SECONDS.sleep(3);
     }
 }


### PR DESCRIPTION
Deleting the file immediately after cancelling the job results in a failed job and a notification email.

Adding a short wait fixes this.

Fixes https://github.com/TheoKanning/openai-java/issues/409