### PR TITLE
Add `response_format` to allow use of new JSON mode

### DIFF
--- a/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionRequest.java
+++ b/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionRequest.java
@@ -30,10 +30,10 @@ public class ChatCompletionRequest {
     /**
      * Must be either 'text' or 'json_object'. <br>
      * When specifying 'json_object' as the request format it's still necessary to instruct the model to return JSON.
-     * You may use {@link ChatResponseFormat} enum.
+     * You may use {@link ChatResponseFormat.ResponseFormat} enum.
      */
     @JsonProperty("response_format")
-    String responseFormat;
+    ChatResponseFormat responseFormat;
 
     /**
      * What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower

--- a/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionRequest.java
+++ b/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionRequest.java
@@ -28,6 +28,14 @@ public class ChatCompletionRequest {
     List<ChatMessage> messages;
 
     /**
+     * Must be either 'text' or 'json_object'. <br>
+     * When specifying 'json_object' as the request format it's still necessary to instruct the model to return JSON.
+     * You may use {@link ChatResponseFormat} enum.
+     */
+    @JsonProperty("response_format")
+    String responseFormat;
+
+    /**
      * What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower
      * values like 0.2 will make it more focused and deterministic.<br>
      * We generally recommend altering this or top_p but not both.

--- a/api/src/main/java/com/theokanning/openai/completion/chat/ChatResponseFormat.java
+++ b/api/src/main/java/com/theokanning/openai/completion/chat/ChatResponseFormat.java
@@ -1,0 +1,19 @@
+package com.theokanning.openai.completion.chat;
+
+/**
+ * see {@link ChatCompletionRequest} documentation.
+ */
+public enum ChatResponseFormat {
+    TEXT("text"),
+    JSON("json");
+
+    private final String value;
+
+    ChatResponseFormat(final String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/api/src/main/java/com/theokanning/openai/completion/chat/ChatResponseFormat.java
+++ b/api/src/main/java/com/theokanning/openai/completion/chat/ChatResponseFormat.java
@@ -1,19 +1,30 @@
 package com.theokanning.openai.completion.chat;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Builder;
+import lombok.Data;
+
 /**
  * see {@link ChatCompletionRequest} documentation.
  */
-public enum ChatResponseFormat {
-    TEXT("text"),
-    JSON("json");
+@Data
+@Builder
+public class ChatResponseFormat {
+    private ResponseFormat type;
 
-    private final String value;
+    public enum ResponseFormat {
+        TEXT("text"),
+        JSON("json_object");
 
-    ChatResponseFormat(final String value) {
-        this.value = value;
-    }
+        private final String value;
 
-    public String value() {
-        return value;
+        ResponseFormat(final String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String value() {
+            return value;
+        }
     }
 }

--- a/service/src/test/java/com/theokanning/openai/service/ChatCompletionTest.java
+++ b/service/src/test/java/com/theokanning/openai/service/ChatCompletionTest.java
@@ -101,10 +101,7 @@ class ChatCompletionTest {
                 .logitBias(new HashMap<>())
                 .build();
 
-        System.out.println(chatCompletionRequest);
-
         ChatCompletionChoice choice = service.createChatCompletion(chatCompletionRequest).getChoices().get(0);
-        System.out.println(choice.getMessage().getContent());
         assertTrue(isValidJson(choice.getMessage().getContent()), "Response is not valid JSON");
     }
 


### PR DESCRIPTION
### Changes
I added an attribute to the ChatCompletionRequest class to support [JSON mode](https://platform.openai.com/docs/guides/text-generation/json-mode). Resolves issue #448 .

### New API Checklist
See CONTRIBUTING.md for more info.

1. [X] Documentation for every variable
2. [X] Class-level documentation
3. [X] POJO JSON parsing tests, _wasn't necessary_
4. [X] Service integration tests