### PR TITLE
Add seed and fingerprint for reproducible outputs.

### DIFF
--- a/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionChunk.java
+++ b/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionChunk.java
@@ -1,4 +1,5 @@
 package com.theokanning.openai.completion.chat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
@@ -27,6 +28,13 @@ public class ChatCompletionChunk {
      * The model used.
      */
     String model;
+
+    /**
+     * The fingerprint denotes the backend configuration used by the model.
+     * Learn more at: https://platform.openai.com/docs/api-reference/chat/streaming#chat/streaming-system_fingerprint
+     */
+    @JsonProperty("system_fingerprint")
+    String fingerprint;
 
     /**
      * A list of all generated completions.

--- a/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionRequest.java
+++ b/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionRequest.java
@@ -48,6 +48,14 @@ public class ChatCompletionRequest {
     Integer n;
 
     /**
+     * For consistent results, use the same seed and parameters in your request.
+     * Set the seed parameter to an integer of your choice and maintain its value across requests for deterministic outputs.
+     *
+     * Determinism cannot be guaranteed, so please refer to the {@link ChatCompletionResult#fingerprint} to track any changes in the backend.
+     */
+    Integer seed;
+
+    /**
      * If set, partial message deltas will be sent, like in ChatGPT. Tokens will be sent as data-only <a
      * href="https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format">server-sent
      * events</a> as they become available, with the stream terminated by a data: [DONE] message.

--- a/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionResult.java
+++ b/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionResult.java
@@ -1,4 +1,5 @@
 package com.theokanning.openai.completion.chat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.theokanning.openai.Usage;
 import lombok.Data;
 
@@ -29,6 +30,13 @@ public class ChatCompletionResult {
      * The GPT model used.
      */
     String model;
+
+    /**
+     * The fingerprint denotes the backend configuration used by the model.
+     * Learn more at: https://platform.openai.com/docs/api-reference/chat/object#chat/object-system_fingerprint
+     */
+    @JsonProperty("system_fingerprint")
+    String fingerprint;
 
     /**
      * A list of all generated completions.


### PR DESCRIPTION

### Changes
- Added 'seed' field parameter to chat completion request for deterministic outputs - [openai documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-seed)
- Added 'fingerprint' field to chat completion result and chunk, denoting backend configuration - [openai documentation](https://platform.openai.com/docs/api-reference/chat/object#chat/object-system_fingerprint)

### New API Checklist
1. [x] Documentation for every variable
2. [x] Class-level documentation