### PR TITLE
Feature: Add dimension paramater in embedding request

### DIFF
--- a/api/src/main/java/com/theokanning/openai/embedding/EmbeddingRequest.java
+++ b/api/src/main/java/com/theokanning/openai/embedding/EmbeddingRequest.java
@@ -36,4 +36,9 @@ public class EmbeddingRequest {
      * A unique identifier representing your end-user, which will help OpenAI to monitor and detect abuse.
      */
     String user;
+
+    /**
+     * The number of dimensions for the embedding. Default value, is not provided, is 1536
+     */
+    int dimensions = 1536;
 }


### PR DESCRIPTION
Thanks for submitting a pull request! Please check CONTRIBUTING.md for style guidelines.

### Changes

Currently the EmbeddingRequest does not have a parameter `dimensions`. So the default value that OpenAPI uses, that is 1536, is set for all the embedding request. If you want to generate embeddings with a reduced dimensions, currently this is not possible.

With the recent launch of new [v3 embedding model](https://openai.com/blog/new-embedding-models-and-api-updates), text-small-3-embedding performs better than ada-002 even with reduced dimension. So this feature can be essential for someone who is looking to save on their storage cost by using a reduced dimension without compromising on the quality of the generated vector embedding 

### New API Checklist
See CONTRIBUTING.md for more info.

1. [x] Documentation for every variable
2. [ ] Class-level documentation
3. [ ] POJO JSON parsing tests
4. [ ] Service integration tests