### PR TITLE
Fix for arguments parsing, loses all encodings otherwise

### DIFF
--- a/service/src/main/java/com/theokanning/openai/service/ChatFunctionCallArgumentsSerializerAndDeserializer.java
+++ b/service/src/main/java/com/theokanning/openai/service/ChatFunctionCallArgumentsSerializerAndDeserializer.java
@@ -44,6 +44,9 @@ public class ChatFunctionCallArgumentsSerializerAndDeserializer {
                 return null;
             }
 
+            // encode to valid JSON escape otherwise we will lose quotes
+            json = MAPPER.writeValueAsString(json);
+
             try {
                 JsonNode node = null;
                 try {


### PR DESCRIPTION
Thanks for submitting a pull request! Please check CONTRIBUTING.md for style guidelines.

### Changes
Added a call to the mapper to encode quotes before decoding them again. Without this fix the JSON arguments string loses all quotes and becomes invalid for parsing later on

### New API Checklist
See CONTRIBUTING.md for more info.

1. [x] Documentation for every variable
2. [x] Class-level documentation
3. [x] POJO JSON parsing tests
4. [x] Service integration tests